### PR TITLE
feat: Read in memory NetCDF files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,18 +16,14 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        xcode: ["13.3.1", "13.2.1", "13.1", "12.5.1", "12.4"]
+        xcode: ["15.4", "15.2", "14.3.1"]
         include:
-          - xcode: "13.3.1"
-            macos: macOS-12
-          - xcode: "13.2.1"
-            macos: macOS-11
-          - xcode: "13.1"
-            macos: macOS-11
-          - xcode: "12.5.1"
-            macos: macOS-11
-          - xcode: "12.4"
-            macos: macOS-11
+          - xcode: "15.4"
+            macos: macOS-14
+          - xcode: "15.2"
+            macos: macOS-14
+          - xcode: "14.3.1"
+            macos: macOS-14
     runs-on: ${{ matrix.macos }}
     name: macOS
     steps:
@@ -62,20 +58,17 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        swift: ["5.6", "5.5", "5.4", "5.3"]
+        swift: ["5.10", "5.9", "5.8"]
         include:
-          - swift: "5.6"
-            container: "swift:5.6"
-            cache-version: 2
-          - swift: "5.5"
-            container: "swift:5.5"
-            cache-version: 2
-          - swift: "5.4"
-            container: "swift:5.4"
-            cache-version: 4
-          - swift: "5.3"
-            container: "swift:5.3"
-            cache-version: 4
+          - swift: "5.10"
+            container: "swift:5.10"
+            cache-version: 1
+          - swift: "5.9"
+            container: "swift:5.9"
+            cache-version: 1
+          - swift: "5.8"
+            container: "swift:5.8"
+            cache-version: 1
     runs-on: ubuntu-20.04
     container: ${{ matrix.container }}
     name: Linux

--- a/README.md
+++ b/README.md
@@ -176,8 +176,8 @@ struct NetCDF {
     static func create(path: String, overwriteExisting: Bool) -> Group
     static func open(path: String, allowUpdate: Bool) -> Group?
     
-    /// Open NetCDF file from memory in read-only mode. Path is only used to set the dataset name.
-    static func open(path: String, memory: UnsafeRawBufferPointer)) -> Group?
+    /// Opens a NetCDF file from memory in read-only mode
+    static func open(memory: UnsafeRawBufferPointer)) -> Group?
 }
 
 struct Group {

--- a/README.md
+++ b/README.md
@@ -175,6 +175,9 @@ SwiftNetCDF uses a simple data structures to organise access to NetCDF functions
 struct NetCDF {
     static func create(path: String, overwriteExisting: Bool) -> Group
     static func open(path: String, allowUpdate: Bool) -> Group?
+    
+    /// Open NetCDF file from memory in read-only mode. Path is only used to set the dataset name.
+    static func open(path: String, memory: UnsafeRawBufferPointer)) -> Group?
 }
 
 struct Group {

--- a/Sources/CNetCDF/shim.h
+++ b/Sources/CNetCDF/shim.h
@@ -1,2 +1,2 @@
- #include <netcdf.h>
- 
+#include <netcdf.h>
+#include <netcdf_mem.h>

--- a/Sources/SwiftNetCDF/Nc.swift
+++ b/Sources/SwiftNetCDF/Nc.swift
@@ -536,7 +536,7 @@ public extension Nc {
         }
     }
     
-    /// Open an exsiting NetCDF file
+    /// Open an existing NetCDF file
     static func open(path: String, omode: Int32) throws -> NcId {
         var ncid: Int32 = 0
         try exec {
@@ -545,7 +545,21 @@ public extension Nc {
         return NcId(ncid)
     }
     
-    /// Open an exsiting NetCDF file
+    /// Open an existing NetCDF file from memory
+    static func open(path: String, memory: UnsafeRawBufferPointer, omode: Int32) throws -> NcId {
+        var ncid: Int32 = 0
+        try exec {
+            nc_open_mem(path, omode, memory.count, UnsafeMutableRawPointer(mutating: memory.baseAddress), &ncid)
+        }
+        return NcId(ncid)
+    }
+    
+    /// Open an existing NetCDF file from memory
+    static func open(path: String, memory: UnsafeRawBufferPointer) throws -> NcId {
+        return try open(path: path, memory: memory, omode: 0)
+    }
+    
+    /// Open an existing NetCDF file
     static func open(path: String, allowUpdate: Bool) throws -> NcId {
         return try open(path: path, omode: allowUpdate ? NC_WRITE : 0)
     }

--- a/Sources/SwiftNetCDF/Nc.swift
+++ b/Sources/SwiftNetCDF/Nc.swift
@@ -555,8 +555,8 @@ public extension Nc {
     }
     
     /// Open an existing NetCDF file from memory
-    static func open(path: String, memory: UnsafeRawBufferPointer) throws -> NcId {
-        return try open(path: path, memory: memory, omode: 0)
+    static func open(memory: UnsafeRawBufferPointer, datasetName: String) throws -> NcId {
+        return try open(path: datasetName, memory: memory, omode: 0)
     }
     
     /// Open an existing NetCDF file

--- a/Sources/SwiftNetCDF/NetCDF.swift
+++ b/Sources/SwiftNetCDF/NetCDF.swift
@@ -59,4 +59,31 @@ public final class NetCDF {
             return nil
         }
     }
+    
+    /**
+     Open a netCDF file with the contents taken from a block of memory.
+     
+     This function opens an existing netCDF dataset for access. It determines the underlying file format automatically. Use the same call to open a netCDF classic or netCDF-4 file.
+     
+     - Parameters:
+        - path: Only used to set the dataset name.
+        - memory: A memory buffer with NetCDF data. Please ensure that the memory adress remaind valid while using the NetCDF handle.
+     
+     - Throws:
+        - `NetCDFError.noPermissions` Attempting to open a netCDF file in a directory where you do not have permission to open files.
+        - `NetCDFError.tooManyOpenFiles` Too many files open
+        - `NetCDFError.outOfMemory` Out of memory
+        - `NetCDFError.hdf5Error` HDF5 error. (NetCDF-4 files only.)
+        - `NetCDFError.netCDF4MetedataError` Error in netCDF-4 dimension metadata. (NetCDF-4 files only.)
+     
+     - Returns: Root group of a NetCDF file or nil if memory cannot be opened as a netcdf handle
+     */
+    public static func open(path: String, memory: UnsafeRawBufferPointer) throws -> Group? {
+        do {
+            let ncid = try Nc.open(path: path, memory: memory)
+            return Group(ncid: ncid, parent: nil)
+        } catch (NetCDFError.noSuchFileOrDirectory) {
+            return nil
+        }
+    }
 }

--- a/Sources/SwiftNetCDF/NetCDF.swift
+++ b/Sources/SwiftNetCDF/NetCDF.swift
@@ -66,8 +66,8 @@ public final class NetCDF {
      This function opens an existing netCDF dataset for access. It determines the underlying file format automatically. Use the same call to open a netCDF classic or netCDF-4 file.
      
      - Parameters:
-        - path: Only used to set the dataset name.
         - memory: A memory buffer with NetCDF data. Please ensure that the memory adress remaind valid while using the NetCDF handle.
+        - datasetName: Can be set to specifiy the name of the dataset
      
      - Throws:
         - `NetCDFError.noPermissions` Attempting to open a netCDF file in a directory where you do not have permission to open files.
@@ -78,9 +78,9 @@ public final class NetCDF {
      
      - Returns: Root group of a NetCDF file or nil if memory cannot be opened as a netcdf handle
      */
-    public static func open(path: String, memory: UnsafeRawBufferPointer) throws -> Group? {
+    public static func open(memory: UnsafeRawBufferPointer, datasetName: String = "dataset") throws -> Group? {
         do {
-            let ncid = try Nc.open(path: path, memory: memory)
+            let ncid = try Nc.open(memory: memory, datasetName: datasetName)
             return Group(ncid: ncid, parent: nil)
         } catch (NetCDFError.noSuchFileOrDirectory) {
             return nil

--- a/Tests/SwiftNetCDFTests/SwiftNetCDFTests.swift
+++ b/Tests/SwiftNetCDFTests/SwiftNetCDFTests.swift
@@ -45,7 +45,7 @@ final class SwiftNetCDFTests: XCTestCase {
         XCTAssertEqual([6, 7, 11, 12], data2)
         
         // Test in memory access
-        var memory = try Data(contentsOf: URL(fileURLWithPath: "test.nc"))
+        let memory = try Data(contentsOf: URL(fileURLWithPath: "test.nc"))
         try memory.withUnsafeBytes({ memory in
             guard let file2 = try NetCDF.open(memory: memory) else {
                 fatalError("File test.nc does not exist")

--- a/Tests/SwiftNetCDFTests/SwiftNetCDFTests.swift
+++ b/Tests/SwiftNetCDFTests/SwiftNetCDFTests.swift
@@ -43,6 +43,18 @@ final class SwiftNetCDFTests: XCTestCase {
         let data2 = try typedVariable.read(offset: [1,1], count: [2,2])
         
         XCTAssertEqual([6, 7, 11, 12], data2)
+        
+        // Test in memory access
+        var memory = try Data(contentsOf: URL(filePath: "test.nc"))
+        try memory.withUnsafeMutableBytes({ memory in
+            guard let file2 = try NetCDF.open(path: "test.nc", memory: memory, allowUpdate: false) else {
+                fatalError("File test.nc does not exist")
+            }
+            guard let title: String = try file2.getAttribute("TITLE")?.read() else {
+                fatalError("TITLE attribute not available or not a String")
+            }
+            XCTAssertEqual(title, "My data set")
+        })
     }
     
     func testCreateGroups() throws {

--- a/Tests/SwiftNetCDFTests/SwiftNetCDFTests.swift
+++ b/Tests/SwiftNetCDFTests/SwiftNetCDFTests.swift
@@ -46,8 +46,8 @@ final class SwiftNetCDFTests: XCTestCase {
         
         // Test in memory access
         var memory = try Data(contentsOf: URL(filePath: "test.nc"))
-        try memory.withUnsafeMutableBytes({ memory in
-            guard let file2 = try NetCDF.open(path: "test.nc", memory: memory, allowUpdate: false) else {
+        try memory.withUnsafeBytes({ memory in
+            guard let file2 = try NetCDF.open(memory: memory) else {
                 fatalError("File test.nc does not exist")
             }
             guard let title: String = try file2.getAttribute("TITLE")?.read() else {

--- a/Tests/SwiftNetCDFTests/SwiftNetCDFTests.swift
+++ b/Tests/SwiftNetCDFTests/SwiftNetCDFTests.swift
@@ -45,7 +45,7 @@ final class SwiftNetCDFTests: XCTestCase {
         XCTAssertEqual([6, 7, 11, 12], data2)
         
         // Test in memory access
-        var memory = try Data(contentsOf: URL(filePath: "test.nc"))
+        var memory = try Data(contentsOf: URL(fileURLWithPath: "test.nc"))
         try memory.withUnsafeBytes({ memory in
             guard let file2 = try NetCDF.open(memory: memory) else {
                 fatalError("File test.nc does not exist")


### PR DESCRIPTION
Support for `nc_open_mem`

Example from unit test:

```swift
var memory = try Data(contentsOf: URL(fileURLWithPath: "test.nc"))
try memory.withUnsafeBytes({ memory in
    guard let file2 = try NetCDF.open(memory: memory) else {
        fatalError("File test.nc does not exist")
    }
    guard let title: String = try file2.getAttribute("TITLE")?.read() else {
        fatalError("TITLE attribute not available or not a String")
    }
    XCTAssertEqual(title, "My data set")
})
```